### PR TITLE
Update workflows to use GH Container Registry

### DIFF
--- a/.github/workflows/push-latest.yml
+++ b/.github/workflows/push-latest.yml
@@ -33,13 +33,20 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build image
-        run: docker image build . --file Dockerfile --tag $ORGANIZATION/$IMAGE_NAME:$IMAGE_TAG
+        run: docker image build . --file Dockerfile --tag $ORGANIZATION/$IMAGE_NAME:$IMAGE_TAG --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG
 
       - name: Login to Docker Hub registry
         run: echo '${{ secrets.DOCKERHUB_PASS }}' | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
-      - name: Push image to registry
+      - name: Push image to Docker Hub registry
         run: docker push $ORGANIZATION/$IMAGE_NAME:$IMAGE_TAG
+
+      # CR_PAT contains a PAT with `write:packages` and `read:packages` scopes
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container registry
+        run: docker push ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$IMAGE_TAG
 
       - name: Save image
         run: docker image save -o $IMAGE_NAME-$IMAGE_TAG.tar $ORGANIZATION/$IMAGE_NAME:$IMAGE_TAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,20 @@ jobs:
         run: echo "::set-env name=IMAGE_RELEASE_TAG::release-${RELEASE_TAG}_terraform-${{ matrix.tf_version }}_azcli-${{ matrix.azcli_version }}"
 
       - name: Build image
-        run: docker image build . --file Dockerfile --build-arg TERRAFORM_VERSION=${{ matrix.tf_version }} --build-arg AZURE_CLI_VERSION=${{ matrix.azcli_version }} --tag ${ORGANIZATION}/${IMAGE_NAME}:${IMAGE_RELEASE_TAG}
+        run: docker image build . --file Dockerfile --build-arg TERRAFORM_VERSION=${{ matrix.tf_version }} --build-arg AZURE_CLI_VERSION=${{ matrix.azcli_version }} --tag ${ORGANIZATION}/${IMAGE_NAME}:${IMAGE_RELEASE_TAG} --tag ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}:${IMAGE_RELEASE_TAG}
 
       - name: Login to Docker Hub registry
         run: echo '${{ secrets.DOCKERHUB_PASS }}' | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
-      - name: Push image to registry
+      - name: Push image to Docker Hub registry
         run: docker push ${ORGANIZATION}/${IMAGE_NAME}:${IMAGE_RELEASE_TAG}
+
+      # CR_PAT secret contains a PAT with `write:packages` and `read:packages` scopes
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container registry
+        run: docker push ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}:${IMAGE_RELEASE_TAG}
 
       - name: Save image
         run: docker image save -o ${IMAGE_NAME}-${IMAGE_RELEASE_TAG}.tar ${ORGANIZATION}/${IMAGE_NAME}:${IMAGE_RELEASE_TAG}


### PR DESCRIPTION
Based on issue #83, I have created this PR.
As described in [Github Docs](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images) Github Packages will be replaced with Github Container Registry, so I have used it.

In order to launch pipelines correctly CR_PAT secret must be created and it contains a Personal Access Token with `write;packages` scope.

More details can be found on this [link](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry)
